### PR TITLE
Extend install instructions; improve `make.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ Make a image of OSM data of an area from 2 dates, showing what was changed.
 
 ## Installation
 
+1. Clone this repo:
+   ```bash
+   git clone --recurse-submodules https://github.com/amandasaurus/osm-mapping-party-before-after
+   ```
 1. [Install `openstreetmap-carto`](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md)
-1. On macOS: [install Homebrew](https://brew.sh/#:~:text=Install%20Homebrew)
+1. *On macOS:* [install Homebrew](https://brew.sh/#:~:text=Install%20Homebrew)
 1. [Install `pipx`](https://pipx.pypa.io/stable/installation/#installing-pipx)
 1. Install [`nik4`](https://github.com/Zverik/Nik4) (used to generate an image with the [`openstreetmap-carto` map style](https://github.com/gravitystorm/openstreetmap-carto/)):
    ```bash
    pipx install nik4
    ```
-1. On macOS: replace built-in `coreutils` commands with the GNU ones:
+1. *On macOS:* replace built-in `coreutils` commands with the GNU ones:
    ```bash
    brew install coreutils
    export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Make a image of OSM data of an area from 2 dates, showing what was changed.
 
 ## Installation
 
-1. [Install `openstreetmap-carto`](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md)
 1. *On macOS:* [install Homebrew](https://brew.sh/#:~:text=Install%20Homebrew)
 1. [Install `pipx`](https://pipx.pypa.io/stable/installation/#installing-pipx)
+1. [Install `openstreetmap-carto`](https://github.com/gravitystorm/openstreetmap-carto/blob/4ec2dc9391c411e124c78b3ba1aad9173fea20cb/INSTALL.md)
+1. Install [`osmium-tool`](https://github.com/osmcode/osmium-tool)
 1. [Install Mapnik](https://github.com/mapnik/mapnik/blob/master/INSTALL.md#source-build)
 1. [Install `python-mapnik`](https://github.com/mapnik/python-mapnik#building-from-source)
 1. Install [`nik4`](https://github.com/Zverik/Nik4) (used to generate an image with the [`openstreetmap-carto` map style](https://github.com/gravitystorm/openstreetmap-carto/)):
    ```bash
    pipx install nik4
    ```
+1. [Install GraphicsMagick](http://www.graphicsmagick.org/README.html#id4)
 1. Clone this repo:
    ```bash
    git clone --recurse-submodules https://github.com/amandasaurus/osm-mapping-party-before-after

--- a/README.md
+++ b/README.md
@@ -1,29 +1,35 @@
-# Mapping before & after
+# Mapping party before–after
 
-Make a image of data of an area in OSM with data from 2 dates, showing what was changed before & after
+Make a image of OSM data of an area from 2 dates, showing what was changed.
 
 ## Installation
 
-This script uses [`nik4`](https://github.com/Zverik/Nik4) to generate an image with the [`openstreetmap-carto` map style](https://github.com/gravitystorm/openstreetmap-carto/)
-
-Follow the [`openstreetmap-carto` installation instructions](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md), first.
-
-Install `nik4`.
-
+1. [Install `openstreetmap-carto`](https://github.com/gravitystorm/openstreetmap-carto/blob/master/INSTALL.md)
+1. On macOS: [install Homebrew](https://brew.sh/#:~:text=Install%20Homebrew)
+1. [Install `pipx`](https://pipx.pypa.io/stable/installation/#installing-pipx)
+1. Install [`nik4`](https://github.com/Zverik/Nik4) (used to generate an image with the [`openstreetmap-carto` map style](https://github.com/gravitystorm/openstreetmap-carto/)):
+   ```bash
+   pipx install nik4
+   ```
+1. On macOS: replace built-in `coreutils` commands with the GNU ones:
+   ```bash
+   brew install coreutils
+   export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH
+   ```
 
 ## Usage
 
-First download an OSM history from, e.g. from [Geofabrik's Download service](https://osm-internal.download.geofabrik.de/). You will need to log in with an OSM account.
+1. Download an OSM history file (`.osh.pbf`) e.g. from [Geofabrik's internal download server](https://osm-internal.download.geofabrik.de/?landing_page=true). You will need to log in with an OSM account.
+1. Calculate the `BBOX` with [BBoxFinder.com](http://bboxfinder.com/).
+    1. *Draw a rectangle*
+    1. Copy the *Box* value
+1. Run the following command:
+    ```bash
+    ./make.sh OSM_HISTORY_FILE.osh.pbf BEFORE_TIME AFTER_TIME BBOX MIN_ZOOM MAX_ZOOM
+    ```
+    The `BEFORE_TIME` & `AFTER_TIME` are ISO 8601 timestamps.
 
-A `BBOX` can be can be calculated with [BBoxFinder.com](http://bboxfinder.com/).
-
-The `BEFORE_TIME` & `AFTER_TIME` are ISO timestamps.
-
-```
-./make.sh OSM_HISTORY_FILE.osh.pbf BEFORE_TIME AFTER_TIME BBOX MIN_ZOOM MAX_ZOOM
-```
-
-## Example
+## Example output
 
 ![Example](sample.png)
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Make a image of OSM data of an area from 2 dates, showing what was changed.
    pipx install nik4
    ```
 1. [Install GraphicsMagick](http://www.graphicsmagick.org/README.html#id4)
-1. Clone this repo:
-   ```bash
-   git clone --recurse-submodules https://github.com/amandasaurus/osm-mapping-party-before-after
-   cd osm-mapping-party-before-after
-   ```
 1. *On macOS:* replace built-in `coreutils` commands with the GNU ones:
    ```bash
    brew install coreutils
    export PATH="$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH
+   ```
+1. Clone this repo:
+   ```bash
+   git clone --recurse-submodules https://github.com/amandasaurus/osm-mapping-party-before-after
+   cd osm-mapping-party-before-after
    ```
 
 ## Usage

--- a/make.sh
+++ b/make.sh
@@ -135,9 +135,9 @@ for ZOOM in $(seq "$MIN_ZOOM" "$MAX_ZOOM") ; do
 		echo "Generating zoom ${ZOOM} level"
 		nik4 openstreetmap-carto/project.xml "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png" -b $BBOX_SPACE -z "$ZOOM" || break
 		NEW="$(mktemp tmp.XXXXXX.png)"
-		gm convert "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png" -background white label:"$TIME_AFTER" -gravity center -append "$NEW"
+		gm convert "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png" -background white -label "$TIME_AFTER" -gravity center -append "$NEW"
 		mv "$NEW" "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png"
-		gm convert "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png" -background white label:"Data © OpenStreetMap contributors, ODbL" -gravity center -append "$NEW"
+		gm convert "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png" -background white -label "Data © OpenStreetMap contributors, ODbL" -gravity center -append "$NEW"
 		mv "$NEW" "$PREFIX.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.png"
 	fi
 done
@@ -154,12 +154,12 @@ for ZOOM in $(seq "$MIN_ZOOM" "$MAX_ZOOM") ; do
 
 	if [ "$BEFORE" -nt "$NEW_PNG" ] || [ "$AFTER" -nt "$NEW_PNG" ] ; then
 		TMP="$(mktemp tmp.XXXXXX.png)"
-		gm montage -geometry +0+0  "$BEFORE" "$AFTER" "$TMP"
-		gm convert "$TMP" -background white label:"Data © OpenStreetMap contributors, ODbL" -gravity center -append "$NEW_PNG"
+		gm montage -geometry +0+0 "$BEFORE" "$AFTER" "$TMP"
+		gm convert "$TMP" -background white -label "Data © OpenStreetMap contributors, ODbL" -gravity center -append "$NEW_PNG"
 	fi
 
 	if [ "$BEFORE" -nt "$NEW_PNG" ] || [ "$AFTER" -nt "$NEW_PNG" ] ; then
-		gm montage -geometry +0+0  "$BEFORE" "$AFTER" "$NEW_PNG"
+		gm montage -geometry +0+0 "$BEFORE" "$AFTER" "$NEW_PNG"
 	fi
 
 	NEW_GIF="progress.$PREFIX.$TIME_BEFORE.$TIME_AFTER.$BBOX_COMMA.z${ZOOM}.gif"

--- a/make.sh
+++ b/make.sh
@@ -67,6 +67,7 @@ fi
 if [ ! -s "$ROOT/openstreetmap-carto/node_modules/.bin/carto" ] ; then
 	cd "$ROOT/openstreetmap-carto"
 	echo "Installing carto into $ROOT/openstreetmap-carto/node_modules with npm..."
+	npm init -y
 	npm install carto -q
 fi
 if [ ! -s "$ROOT/openstreetmap-carto/project.xml" ] ; then


### PR DESCRIPTION
- Fix #2 
- Extend install instructions
  - Add steps for macOS
  - Add `git clone` command
  - Add BBoxFinder.com instructions 
- Improve `make.sh`
  - Add `npm init -y` to enable local package installation
  - Fix `gm convert` `-label` flags

Unfortunately I still couldn't get it working—see https://github.com/amandasaurus/osm-mapping-party-before-after/issues/4 for more details.