### PR TITLE
Create docker image to run make.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM postgis/postgis:15-3.5 AS development_build
+
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends \
+ ca-certificates gnupg lsb-release locales \
+ wget curl \
+ git-core unzip \
+&& locale-gen $LANG && update-locale LANG=$LANG 
+
+
+# Get packages
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends \
+ make \
+ fonts-hanazono \
+ fonts-noto-cjk \
+ fonts-noto-hinted \
+ fonts-noto-unhinted \
+ fonts-unifont \
+ gdal-bin \
+ graphicsmagick \
+ liblua5.3-dev \
+ libosmium2-dev \
+ libprotozero-dev \
+ lua5.3 \
+ mapnik-utils \
+ npm \
+ osm2pgsql \
+ osmium-tool \
+ osmosis \
+ python-is-python3 \
+ python3-mapnik \
+ python3-lxml \
+ python3-psycopg2 \
+ python3-shapely \
+ python3-pip \
+ sudo \
+ vim \
+&& apt-get clean autoclean \
+&& apt-get autoremove --yes \
+&& rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+RUN wget https://downloads.sourceforge.net/gs-fonts/ghostscript-fonts-std-8.11.tar.gz
+RUN tar xvf ghostscript-fonts-std-8.11.tar.gz
+RUN mkdir -p /usr/share/fonts/type1/
+RUN mv fonts/ /usr/share/fonts/type1/gsfonts
+
+# Install python libraries
+
+RUN pip install pyyaml nik4 requests
+
+# Install carto for stylesheet
+RUN npm install -g carto@1.2.0
+
+
+COPY . /workdir
+
+RUN mkdir -p /workdir/openstreetmap-carto/data 
+RUN mkdir -p /workdir/output
+
+WORKDIR /workdir
+
+RUN chown postgres:postgres -R /workdir  
+
+USER postgres

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then we build the image that is specified in the `Dockerfile`, picking a name fo
 Depending on how you installed Docker, you might have to run `sudo` for each `docker` command.
 
  ```bash
-`docker build -t before_after_builder
+docker build -t before_after_builder
 ```
 
 This step needs to be run only once, and it can take a few minutes as it will download and build all the dependencies needed. 
@@ -61,7 +61,7 @@ These volumes are used to store external data, i.e. the database contents and th
 Once the docker container is running, you can connect into it to get a bash inside to run the commands as outlined below using:
 
 ```bash
-docker exec -ti map-before-after before_after_builder
+docker exec -ti map-before-after bash
 ```
 
 The resulting shell puts you into the equivalent of the root of this repository, in a folder called `/workdir`. From there you can use this repository as outlined below. 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,48 @@ Make a image of OSM data of an area from 2 dates, showing what was changed.
    cd osm-mapping-party-before-after
    ```
 
+### Install & use via Docker image
+
+Alternatively, if you do not want to install the whole pipeline yourself, you can run this setup in a Docker container that is ready to use.
+We start, by cloning this repository:
+
+```bash
+git clone --recurse-submodules https://github.com/amandasaurus/osm-mapping-party-before-after
+cd osm-mapping-party-before-after
+   ```
+Then we build the image that is specified in the `Dockerfile`, picking a name for the image, e.g. `before_after_builder`.
+Depending on how you installed Docker, you might have to run `sudo` for each `docker` command.
+
+ ```bash
+`docker build -t before_after_builder
+```
+
+This step needs to be run only once, and it can take a few minutes as it will download and build all the dependencies needed. 
+Once the step is finished, you can launch the container like so:
+
+```bash
+./docker_run.sh before_after_builder /full/path/to/in-out-dir/ 
+```
+
+The command takes two parameters:
+
+1. the name of the container (as specified above)
+2. a full path to a directory you want to use for accessing and writing files to from the container (i.e. Input and output files). Depending on how you installed/run Docker, this folder might need full read/write permissions for other users (e.g. run `chmod 777`). 
+
+The `docker_run.sh` command will launch the container itself, including the necessary postgres database etc.
+It will also create two virtual docker volumes (named `pgdata` and `osm_data`). 
+These volumes are used to store external data, i.e. the database contents and the `openstreetmap-carto` external files.
+
+Once the docker container is running, you can connect into it to get a bash inside to run the commands as outlined below using:
+
+```bash
+docker exec -ti map-before-after before_after_builder
+```
+
+The resulting shell puts you into the equivalent of the root of this repository, in a folder called `/workdir`. From there you can use this repository as outlined below. 
+
+All output files are saved in the `/workdir` by default, you can from there move them into `/workdir/output` inside the container to access files on your host operating system.
+
 ## Usage
 
 1. Download an OSM history file (`.osh.pbf`) e.g. from [Geofabrik's internal download server](https://osm-internal.download.geofabrik.de/?landing_page=true). You will need to log in with an OSM account.

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# run docker with correct minimal settings to mount 
+# a) postgres db 
+# b) opencarto data directory
+# c) import/export directory for files
+# and also use correct user etc
+
+# Requires 1 parameters: 1. name of the docker image, 2. full path to input/output directory
+# depending on your setup, the input/output directory needs to have `chmod 777` on the directory to work
+
+IMAGE_NAME=$1
+OUTPUT_DIR=$2
+
+
+docker run --rm -e POSTGRES_PASSWORD="unused" -v pgdata:/var/lib/postgresql/data -v osm_data:/workdir/openstreetmap-carto/data -v $OUTPUT_DIR:/workdir/output --name map-before-after $IMAGE_NAME


### PR DESCRIPTION
[As chatted about on Mastodon a while ago](https://en.osm.town/@amapanda/113557010553759989), I made some progress on creating a Docker image that provides all the dependencies to run the main `make.sh` inside it, without having to install any of the dependencies on the host operating system. 

Overall, it seems to work really well, but I want to flag that I had to make some modifications in the `make.sh` too, which I'm not sure are due to the fact that I put everything into the container, outdated/different dependencies or whatever else. In detail those are: 

1. I moved the check for the presence of the database to happen before running carto's `get-external-data.py`. That way the extensions etc are loaded for that step, otherwise it crashed for me, as `get-external-data.py` relied on those being present. This should otherwise not make a difference
2. I had to rename the `nik4` commands to `nik4.py`, as otherwise those wouldn't be found. I'm not sure if this is generally now the right way to run it or whether I did something wrong there? :thinking: 
3. The creation of the captions using `gm` was (and still is) weird. It would only duplicate the OSM credits, and never give the timestamps. I modified those to now display both bits on each half of the image. 

Hopefully this provides a half-way reasonable starting point for looking over it and happy to work more on it! 