### PR TITLE
start container build automation

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,4 +1,3 @@
-#
 name: Create and publish a Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
@@ -21,7 +20,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-      # 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,51 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['automate_build']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['automate_build']
+    branches: ['main']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you want to use the _MyBinder_ version, [click here and wait a bit](https://m
 
 The MyBinder version has two drawbacks: 1. You will have to upload the OSM history file (_\*.osh.pbf_) into the container. Depending on the region of interest these can be quite large. 2. Creating the maps will take longer, as other external downloads will have to be downloaded on the fly. See [this blog post for more details](https://tzovar.as/map-comparisons/).
 
-If you want to run the Docker image on your own computer, you can find the necessary [image is available on Docker Hub under `gedankenstuecke/osm-mapping-party-before-after`](https://hub.docker.com/r/gedankenstuecke/osm-mapping-party-before-after). 
+If you want to run the Docker image on your own computer, you can find the necessary [image is available on the GitHub Container Registry under `amandasaurus/osm-mapping-party-before-after`](https://github.com/amandasaurus/osm-mapping-party-before-after/pkgs/container/osm-mapping-party-before-after). 
 
 ### Building the Docker container from scratch
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you want to use the _MyBinder_ version, [click here and wait a bit](https://m
 
 The MyBinder version has two drawbacks: 1. You will have to upload the OSM history file (_\*.osh.pbf_) into the container. Depending on the region of interest these can be quite large. 2. Creating the maps will take longer, as other external downloads will have to be downloaded on the fly. See [this blog post for more details](https://tzovar.as/map-comparisons/).
 
-If you want to run the Docker image on your own computer, you can find the necessary [image is available on the GitHub Container Registry under `amandasaurus/osm-mapping-party-before-after`](https://github.com/amandasaurus/osm-mapping-party-before-after/pkgs/container/osm-mapping-party-before-after). 
+If you want to run the Docker image on your own computer, the necessary image is available in the GitHub Container registry under [`amandasaurus/osm-mapping-party-before-after`](https://github.com/amandasaurus/osm-mapping-party-before-after/pkgs/container/osm-mapping-party-before-after). 
 
 ### Building the Docker container from scratch
 


### PR DESCRIPTION
Thanks again to @gy-mate for suggesting this. This PR would automate building the latest image and pushing it to the container registry. 

Unlike the prior containers, this would be hosted on the GitHub container registry, as this one ties into the repos themselves, rather than requiring figuring out how to share my credentials. The resulting containers will then be be available under `https://github.com/amandasaurus/osm-mapping-party-before-after/pkgs/container/osm-mapping-party-before-after`. 

The images can be pulled like this: `docker pull ghcr.io/amandasaurus/osm-mapping-party-before-after:main`. 

Until this PR is merged, those images won't exist, but you can see an example from my fork for the PR here: https://github.com/gedankenstuecke/osm-mapping-party-before-after/pkgs/container/osm-mapping-party-before-after

This closes #11

