### PR TITLE
Fix GH docker reg version of image 

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: 'true'
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1


### PR DESCRIPTION
This closes #13. 

The problem was indeed that the default workflows used for the creation of the Docker container on GH do not check out the submodules (while MyBinder does!), so it would fail. I've adapted the GH workflow file to explicitly also checkout the submodules, now the image works (c.f. my fork) :-) 